### PR TITLE
Task revisit

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,62 @@ and then require the task:
 Run the `mvn` task:
 
     Options:
-      -h, --help             Print this help info.
-      -A, --args ARGS        ARGS sets maven commands and options.
-      -V, --version VERSION  VERSION sets maven version.
-      -F, --file FILE        FILE sets file name (default is pom.xml).
-    
+      -h, --help             Print this help info
+      -A, --args ARGS        sets maven commands and options
+      -V, --version VERSION  sets maven version
+      -F, --file FILE        sets file name (default is pom.xml)
+      -W, --working-dir PATH sets the working dir, in this case the output won't be on the fileset
+
 e.g.
 
     $ boot mvn --args "clean compile install"
     $ boot mvn --args -V
     $ boot mvn --args jetty:run
     $ boot mvn --version 3.2.1 --args "compile install"
-    
+
 All examples assume that there is a pom.xml (or a differently named file as per `--file` parameter) available in the task fileset.
+
+## Task description
+
+> Run Maven commands from Boot
+>
+> Given that you are consciously using a build tool inside a build tool, there
+> are going to be some bumps.
+>
+> The main one is about the output folder: by default Maven outputs to
+> working-dir/target. In the default case (--working-dir is missing) your
+> output will be materialized on the fileset, so don't be surprised if you see
+> target/target when using the target task.
+>
+> If you want to change the name of Maven's output, you can add a profile to
+> you pom.xml with content:
+>
+>     <profiles>
+>       <profile>
+>         <id>boot-clj</id>
+>         <build>
+>           <directory>mvn-target</directory>
+>         </build>
+>       </profile>
+>     </profiles>
+>
+> And call the task with (assuming pom.xml in .):
+>
+>     boot -B --source-paths . mvn -A \"-Pboot-clj clean install\" target
+>
+> This will materialize both `target/` and `mvn-target/`.
+>
+> If --W|--working-dir is specified, this dir will be used instead. This means
+> that the output will NOT be materialized on the fileset and, if no profile
+> customizes build.directory, the Maven output will be in target/.
+
+> Except that if you are using also Boot's target task, your final target/ will
+> end up being overwritten by Boot and you won't see Maven output at all.  This
+> means that when using --working-dir, you always want to use the profile
+> approach.
+>
+> By the default if the pom file is not found a warning is emitted but the next
+> task in the pipeline is called."
 
 ## License
 

--- a/build.boot
+++ b/build.boot
@@ -1,9 +1,8 @@
 (def project 'big-solutions/boot-mvn)
-(def version "0.1.5")
+(def version "0.1.6")
 
 (set-env! :source-paths #{"src"}
           :dependencies   '[[org.clojure/clojure "1.7.0"]
-
                             [boot/core "2.6.0" :scope "test"]])
 
 (task-options!

--- a/src/boot_mvn/core.clj
+++ b/src/boot_mvn/core.clj
@@ -2,14 +2,25 @@
   {:boot/export-tasks true}
   (:require [boot.core :as boot :refer [deftask *boot-version*]]
             [boot.pod :as pod]
-            [clojure.java.io :as io]))
+            [boot.util :as util]
+            [clojure.java.io :as io])
+  (:import [java.io File]))
 
-(defn maven-pod* [version]
-  (pod/make-pod {:dependencies [['org.apache.maven/maven-embedder version :scope "test"]]}))
+;; (set! *warn-on-reflection* true)
 
-(def maven-pod
-  (memoize maven-pod*))
+;; http://stackoverflow.com/questions/28385197/maven-embedder-compiler-dependency-could-not-be-resolved-no-connector-factori
+(def ^:private wagon-version "2.10")
+(def ^:private aether-conn-version "1.1.0")
+(def ^:private slf4j-version "1.7.22")
 
+(defn maven-pod [embedder-version]
+  (future (pod/make-pod (-> (boot/get-env)
+                            (assoc :dependencies [['org.apache.maven/maven-embedder embedder-version]
+                                                  ['org.eclipse.aether/aether-connector-basic aether-conn-version]
+                                                  ['org.eclipse.aether/aether-transport-wagon aether-conn-version]
+                                                  ['org.apache.maven.wagon/wagon-http wagon-version]
+                                                  ['org.apache.maven.wagon/wagon-provider-api wagon-version]
+                                                  ['org.slf4j/slf4j-simple slf4j-version]])))))
 
 (deftask mvn
   "Run Maven commands from Boot"
@@ -17,26 +28,42 @@
    V version VERSION str "Maven version"
    F file FILE str "File name (default is pom.xml)"]
 
-  (let [tmp (boot/tmp-dir!)
+  (let [tmp ^File (boot/tmp-dir!)
         tmp-path (.getAbsolutePath tmp)
-        pom-name (or file "pom.xml")]
+        pom-name (or file "pom.xml")
+        pod-future (maven-pod (or version "3.3.9"))]
     (fn middleware [next-handler]
-     (fn handler [fileset]
-       (boot/empty-dir! tmp)
-       (let [pom (->> fileset
+      (fn handler [fileset]
+        (boot/empty-dir! tmp)
+
+        ;; Necessary or an exception will be thrown
+        (System/setProperty "maven.multiModuleProjectDirectory" tmp-path)
+
+        (util/dbug* "M2_HOME %s\n" (System/getenv "M2_HOME"))
+        (util/dbug* "maven.repo.local %s\n" (System/getProperty "maven.repo.local"))
+        (util/dbug* "user.home %s\n" (System/getProperty "user.home"))
+        (util/dbug* "maven.multiModuleProjectDirectory %s\n" (System/getProperty "maven.multiModuleProjectDirectory"))
+
+        (if-let [pom (->> fileset
                           boot/input-files
-                          (boot/by-name [pom-name])
-                          first
-                          boot/tmp-file
-                          slurp)
-             pod (maven-pod (or version "3.1.1"))]
+                          (boot/by-path [pom-name])
+                          first)]
+          (let [pom-content (-> pom
+                                boot/tmp-file
+                                slurp)]
+            (spit (io/file tmp "pom.xml") pom-content)
 
-          (spit (io/file tmp "pom.xml") pom)
+            (pod/with-eval-in @pod-future
+              (require '[boot.util :as util])
+              (require '[boot.pod :as pod])
+              (import [org.apache.maven.cli MavenCli])
 
-          (pod/with-eval-in pod
-                            (.doMain (new org.apache.maven.cli.MavenCli)
-                                     (.split ^String ~args "\\s+")
-                                     ~tmp-path System/out System/err))
-          (next-handler (-> fileset
-                            (boot/add-resource tmp)
-                            boot/commit!)))))))
+              (let [arg-split (into-array String (.split ^String ~args "\\s+"))]
+                (util/dbug* "MavenCli args %s\n" (util/pp-str arg-split))
+                (.doMain (MavenCli.) arg-split ~tmp-path System/out System/err)))
+
+            (next-handler (-> fileset
+                              (boot/add-resource tmp)
+                              boot/commit!)))
+          (throw (ex-info (format "The %s file cannot be found, be sure the file exists and it is on the classpath (double-check your set-env!)" pom-name)
+                          {:pom-name pom-name})))))))

--- a/src/boot_mvn/core.clj
+++ b/src/boot_mvn/core.clj
@@ -23,47 +23,89 @@
                                                   ['org.slf4j/slf4j-simple slf4j-version]])))))
 
 (deftask mvn
-  "Run Maven commands from Boot"
+  "Run Maven commands from Boot
+
+  Given that you are consciously using a build tool inside a build tool, there
+  are going to be some bumps.
+
+  The main one is about the output folder: by default Maven outputs to
+  working-dir/target. In the default case (--working-dir is missing) your
+  output will be materialized on the fileset, so don't be surprised if you see
+  target/target when using the target task.
+
+  If you want to change the name of Maven's output, you can add a profile to
+  you pom.xml with content:
+
+    <profiles>
+      <profile>
+        <id>boot-clj</id>
+        <build>
+          <directory>mvn-target</directory>
+        </build>
+      </profile>
+    </profiles>
+
+  And call the task with (assuming pom.xml in .):
+
+    boot -B --source-paths . mvn -A \"-Pboot-clj clean install\" target
+
+  This will materialize target/mvn-target.
+
+  If --W|--working-dir is specified, this dir will be used instead. This means
+  that the output will NOT be materialized on the fileset and, if no profile
+  customizes build.directory, the Maven output will be in target/.
+
+  Except that if you are using also Boot's target task, your final target/ will
+  end up being overwritten by Boot and you won't see Maven output at all.  This
+  means that when using --working-dir, you always want to use the profile
+  approach.
+
+  By the default if the pom file is not found a warning is emitted but the next
+  task in the pipeline is called."
+
   [A args ARGS str "Maven commands and options"
    V version VERSION str "Maven version"
-   F file FILE str "File name (default is pom.xml)"]
+   F file FILE str "File name (default is pom.xml)"
+   W working-dir PATH str "The working dir, in this case the output won't be on the fileset"]
 
-  (let [tmp ^File (boot/tmp-dir!)
-        tmp-path (.getAbsolutePath tmp)
+  (let [tmp ^File (when-not working-dir (boot/tmp-dir!))
         pom-name (or file "pom.xml")
         pod-future (maven-pod (or version "3.3.9"))]
     (fn middleware [next-handler]
       (fn handler [fileset]
-        (boot/empty-dir! tmp)
+        (when-not working-dir (boot/empty-dir! tmp))
 
-        ;; Necessary or an exception will be thrown
-        (System/setProperty "maven.multiModuleProjectDirectory" tmp-path)
+        (let [working-dir (or working-dir (.getCanonicalPath tmp))]
+          (if-let [pom (->> fileset
+                            boot/input-files
+                            (boot/by-path [pom-name])
+                            first)]
+            (let [pom-content (-> pom boot/tmp-file slurp)]
+              (when-not working-dir
+                (util/warn "%s content\n%s\n" pom-name pom-content)
+                (spit (io/file working-dir "pom.xml") pom-content))
 
-        (util/dbug* "M2_HOME %s\n" (System/getenv "M2_HOME"))
-        (util/dbug* "maven.repo.local %s\n" (System/getProperty "maven.repo.local"))
-        (util/dbug* "user.home %s\n" (System/getProperty "user.home"))
-        (util/dbug* "maven.multiModuleProjectDirectory %s\n" (System/getProperty "maven.multiModuleProjectDirectory"))
+              (pod/with-eval-in @pod-future
+                (require '[boot.util :as util])
+                (require '[boot.pod :as pod])
+                (import [org.apache.maven.cli MavenCli])
+                (import [java.lang System])
+                ;; Necessary or an exception will be thrown
+                (System/setProperty "maven.multiModuleProjectDirectory" ~working-dir)
 
-        (if-let [pom (->> fileset
-                          boot/input-files
-                          (boot/by-path [pom-name])
-                          first)]
-          (let [pom-content (-> pom
-                                boot/tmp-file
-                                slurp)]
-            (spit (io/file tmp "pom.xml") pom-content)
+                (util/dbug* "PWD %s\n" (System/getenv "PWD"))
+                (util/dbug* "M2_HOME %s\n" (System/getenv "M2_HOME"))
+                (util/dbug* "maven.repo.local %s\n" (System/getProperty "maven.repo.local"))
+                (util/dbug* "user.home %s\n" (System/getProperty "user.home"))
+                (util/dbug* "maven.multiModuleProjectDirectory %s\n" (System/getProperty "maven.multiModuleProjectDirectory"))
+                (util/dbug* "working-dir %s\n" ~working-dir)
 
-            (pod/with-eval-in @pod-future
-              (require '[boot.util :as util])
-              (require '[boot.pod :as pod])
-              (import [org.apache.maven.cli MavenCli])
-
-              (let [arg-split (into-array String (.split ^String ~args "\\s+"))]
-                (util/dbug* "MavenCli args %s\n" (util/pp-str arg-split))
-                (.doMain (MavenCli.) arg-split ~tmp-path System/out System/err)))
-
-            (next-handler (-> fileset
+                (let [arg-split (.split ^String ~args "\\s+")]
+                  (util/dbug* "MavenCli args %s\n" (util/pp-str arg-split))
+                  (.doMain (MavenCli.) arg-split ~working-dir System/out System/err))))
+            (util/warn "The %s file cannot be found, be sure the file exists and it is on the classpath (double-check your set-env!). Ignoring the Maven build..." pom-name))
+          (next-handler (if-not working-dir
+                          (-> fileset
                               (boot/add-resource tmp)
-                              boot/commit!)))
-          (throw (ex-info (format "The %s file cannot be found, be sure the file exists and it is on the classpath (double-check your set-env!)" pom-name)
-                          {:pom-name pom-name})))))))
+                              boot/commit!)
+                          fileset)))))))


### PR DESCRIPTION
A bunch of new things:

#### The working dir can be set and defaults to `$PWD`:

The folder is not on the (tmp) fileset anymore, because Maven won't see `:source-paths` or `:resource-paths` (because the tmp is initially empty) otherwise.

The above also means that Maven will write to `working-dir` its output. This might clash with boot's (same `target` default) so in order to avoid this a profile needs to be configured in the `pom.xml`:

     <profiles>
       <profile>
         <id>boot-clj</id>
         <build>
           <directory>mvn-target</directory>
         </build>
       </profile>
     </profiles>

I tried to automatically set either `build.directory` or `project.build.outputDirectory` with no luck, so I [had to settle](http://stackoverflow.com/questions/3908013/maven-how-to-change-path-to-target-directory-from-command-line#3908061) for this solution.

#### Pom.xml not found emits a warning

I wanted to initially throw, but given that the two build tool are separate entities, it is better to warn and continue. In the future we can add a `--fail` option.

#### Add Aether and Wagon deps to the pod

I had to do it, `MavenCli` could not read deps or plugins.

#### Bump `maven-embedder` to 3.3.9

This also required to explicitly set `maven.multiModuleProjectDirectory` to `working-dir`.

Having said that, these are massive and breaking changes that you should feel free to reject.
I might actually create another project if you do, but your project name is compelling, and you could just bump the major version.
